### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,5 +1,7 @@
 name: yamllint
 on: push
+permissions:
+  contents: read
 jobs:
   build:
     name: yamllint


### PR DESCRIPTION
Potential fix for [https://github.com/rummsi1337/live-node-monitor/security/code-scanning/9](https://github.com/rummsi1337/live-node-monitor/security/code-scanning/9)

Add an explicit `permissions` block to `.github/workflows/yamllint.yaml` at the workflow root level so it applies to all jobs in this workflow.  
For this workflow’s current behavior (checkout + lint), the least-privilege setting is:

- `contents: read`

This preserves existing functionality while preventing inherited broader token scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
