### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-black.yaml
+++ b/.github/workflows/python-black.yaml
@@ -1,5 +1,7 @@
 name: python-black
 on: push
+permissions:
+  contents: read
 
 jobs:
   python-black:


### PR DESCRIPTION
Potential fix for [https://github.com/rummsi1337/live-node-monitor/security/code-scanning/5](https://github.com/rummsi1337/live-node-monitor/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.  
Best single fix without changing functionality: add workflow-level permissions with `contents: read` right after the `on` section in `.github/workflows/python-black.yaml`. This is sufficient for `actions/checkout` reading repository content and for running Black checks, while preserving current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
