### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,6 +1,8 @@
 # yamllint disable rule:line-length
 name: test
 on: push
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/rummsi1337/live-node-monitor/security/code-scanning/8](https://github.com/rummsi1337/live-node-monitor/security/code-scanning/8)

Add an explicit `permissions` block to `.github/workflows/pytest.yaml` at the workflow root level (right after `on:` is a clear location). For this test workflow, the minimal required permission is:

- `contents: read`

This allows `actions/checkout` to read repository contents and keeps the token restricted. No other functionality in the shown workflow requires write scopes, so this change preserves behavior while satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
