### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/isort.yaml
+++ b/.github/workflows/isort.yaml
@@ -1,6 +1,8 @@
 # yamllint disable rule:line-length
 name: isort
 on: push
+permissions:
+  contents: read
 
 jobs:
   isort:


### PR DESCRIPTION
Potential fix for [https://github.com/rummsi1337/live-node-monitor/security/code-scanning/7](https://github.com/rummsi1337/live-node-monitor/security/code-scanning/7)

Add an explicit `permissions` block in `.github/workflows/isort.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves current behavior (checkout and read-only operations continue to work) while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
