### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -1,5 +1,7 @@
 name: workflow-lint
 on: push
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/rummsi1337/live-node-monitor/security/code-scanning/6](https://github.com/rummsi1337/live-node-monitor/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best minimal fix here is at the workflow root (applies to all jobs unless overridden), with:

- `contents: read`

This preserves current functionality for a lint workflow and satisfies the CodeQL recommendation.  
Change file: `.github/workflows/workflow-lint.yaml`, near the top-level keys (after `on` is a clear location), before `jobs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
